### PR TITLE
feat(profile): add update and delete endpoints for user profile

### DIFF
--- a/app/Helpers/ValidationHelper.php
+++ b/app/Helpers/ValidationHelper.php
@@ -15,8 +15,6 @@ class ValidationHelper
                 'email' => 'required|email|unique:users,email',
                 'password' => 'required|string|min:8|regex:/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/',
                 'role' => 'required|in:teacher,student,admin',
-                'avatar' => 'nullable|url',
-                'bio' => 'nullable|string|max:1000',
             ],
             [
                 'name.required' => 'Name is required',
@@ -27,8 +25,6 @@ class ValidationHelper
                 'password.min' => 'Password must be at least 8 characters',
                 'role.required' => 'Role is required',
                 'role.in' => 'Role must be teacher, student, or admin',
-                'avatar.url' => 'Avatar must be a valid URL',
-                'bio.max' => 'Bio must be at most 1000 characters',
             ],
         );
     }
@@ -46,6 +42,32 @@ class ValidationHelper
                 'email.email' => 'Email must be a valid email address',
                 'password.required' => 'Password is required',
             ],
+        );
+    }
+
+    public static function profile($data)
+    {
+        return Validator::make(
+            $data,
+            [
+                'name' => 'required|string|max:255',
+                'email' => 'required|email|unique:users,email,' . auth()->user()->id,
+                'role' => 'required|in:teacher,student,admin',
+                'avatar' => 'nullable|file|mimetypes:image/jpeg,image/png,image/jpg|max:2048',
+                'bio' => 'nullable|string',
+            ],
+            [
+                'name.required' => 'Name is required',
+                'email.required' => 'Email is required',
+                'email.email' => 'Email must be a valid email address',
+                'email.unique' => 'Email already exists',
+                'role.required' => 'Role is required',
+                'role.in' => 'Role must be teacher, student, or admin',
+                'avatar.file' => 'Avatar must be a file',
+                'avatar.mimetypes' => 'Avatar must be a JPEG, PNG, or JPG file',
+                'avatar.max' => 'Avatar size must be at most 2MB',
+                'bio.string' => 'Bio must be a string',
+            ]
         );
     }
 

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -74,8 +74,6 @@ class AuthController extends Controller
                 'email' => $data['email'],
                 'password' => Hash::make($data['password']),
                 'role' => $data['role'],
-                'avatar' => $data['avatar'] ?? null,
-                'bio' => $data['bio'] ?? null,
             ]);
 
             Auth::login($user);

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Helpers\ValidationHelper;
+use App\Helpers\FileUploadHelper;
+use DB;
+
+class UserController extends Controller
+{
+    /**
+     * @OA\Post(
+     *     path="/api/profile/update",
+     *     tags={"Profile"},
+     *     summary="Update user profile",
+     *     description="Update authenticated user's profile including name, email, role, avatar, and bio.",
+     *     security={{"sanctum":{}}},
+     *     @OA\Parameter(
+     *         name="X-XSRF-TOKEN",
+     *         in="header",
+     *         required=false,
+     *         description="CSRF token for session-based auth (Sanctum)",
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\Parameter(
+     *         name="Referer",
+     *         in="header",
+     *         required=false,
+     *         description="Referring URL Frontend for CSRF protection",
+     *         @OA\Schema(type="string", example="http://localhost:3000")
+     *     ),
+     *     @OA\Parameter(
+     *         name="_method",
+     *         in="query",
+     *         required=true,
+     *         description="Override HTTP method for PATCH requests",
+     *         @OA\Schema(type="string", example="PATCH")
+     *     ),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\MediaType(
+     *             mediaType="multipart/form-data",
+     *             @OA\Schema(
+     *                 required={"name", "email", "role"},
+     *                 @OA\Property(property="name", type="string", example="Fika"),
+     *                 @OA\Property(property="email", type="string", format="email", example="student2@example.com"),
+     *                 @OA\Property(property="role", type="string", enum={"student", "teacher", "admin"}, example="student"),
+     *                 @OA\Property(property="bio", type="string", example="Lorem ipsum dolor sit amet"),
+     *                 @OA\Property(
+     *                     property="avatar",
+     *                     type="string",
+     *                     format="binary",
+     *                     description="User avatar image file"
+     *                 )
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="User updated successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="User updated successfully"),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="id", type="string", example="d2fb93ec-6043-4384-814d-0e48f36aed50"),
+     *                 @OA\Property(property="name", type="string", example="Fika"),
+     *                 @OA\Property(property="email", type="string", example="student2@example.com"),
+     *                 @OA\Property(property="email_verified_at", type="string", nullable=true, example=null),
+     *                 @OA\Property(property="role", type="string", example="student"),
+     *                 @OA\Property(property="avatar", type="string", example="/storage/avatar/687f8636256b0.png"),
+     *                 @OA\Property(property="bio", type="string", example="Lorem ipsum dolor sit amet"),
+     *                 @OA\Property(property="created_at", type="string", format="date-time", example="2025-07-17T07:08:54.000000Z"),
+     *                 @OA\Property(property="updated_at", type="string", format="date-time", example="2025-07-22T12:38:14.000000Z")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated"
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Validation errors",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="errors", type="object")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Server error"
+     *     )
+     * )
+     */
+    public function update(Request $request)
+    {
+        DB::beginTransaction();
+        try {
+            $user = auth()->user();
+            if (!$user) {
+                return response()->json(['message' => 'User not found'], 404);
+            }
+
+            $validator = ValidationHelper::profile($request->all());
+            if ($validator->fails()) {
+                return response()->json(['errors' => $validator->errors()], 422);
+            }
+
+            $data = $validator->validated();
+
+            if ($request->hasFile('avatar')) {
+                if ($user->avatar) {
+                    FileUploadHelper::delete($user->avatar);
+                }
+                $data['avatar'] = FileUploadHelper::upload($request->file('avatar'), 'avatar');
+            }
+
+            $user->update($data);
+
+            DB::commit();
+            return response()->json(['message' => 'User updated successfully', 'data' => $user], 200);
+        } catch (\Exception $e) {
+            DB::rollBack();
+            return response()->json(['message' => 'Server error', 'error' => $e->getMessage()], 500);
+        }
+    }
+
+    /**
+     * @OA\Delete(
+     *     path="/api/profile/destroy",
+     *     tags={"Profile"},
+     *     summary="Delete user profile",
+     *     description="Delete the authenticated user's account, including avatar file if present.",
+     *     security={{"sanctum":{}}},
+     *     @OA\Parameter(
+     *         name="X-XSRF-TOKEN",
+     *         in="header",
+     *         required=false,
+     *         description="CSRF token for session-based auth (Sanctum)",
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\Parameter(
+     *         name="Referer",
+     *         in="header",
+     *         required=false,
+     *         description="Referring URL Frontend for CSRF protection",
+     *         @OA\Schema(type="string", example="http://localhost:3000")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="User deleted successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="User deleted successfully")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Unauthenticated"
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="User not found"
+     *     ),
+     *     @OA\Response(
+     *         response=500,
+     *         description="Server error"
+     *     )
+     * )
+     */
+    public function destroy(Request $request)
+    {
+        DB::beginTransaction();
+        try {
+            $user = auth()->user();
+            if (!$user) {
+                return response()->json(['message' => 'User not found'], 404);
+            }
+
+            if ($user->avatar) {
+                FileUploadHelper::delete($user->avatar);
+            }
+
+            $user->delete();
+            DB::commit();
+            return response()->json(['message' => 'User deleted successfully'], 200);
+        } catch (\Exception $e) {
+            DB::rollBack();
+            return response()->json(['message' => 'Server error', 'error' => $e->getMessage()], 500);
+        }
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,6 +3,7 @@
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\AuthController;
+use App\Http\Controllers\UserController;
 use App\Http\Controllers\VocabularyCategoryController;
 use App\Http\Controllers\VocabularyController;
 use App\Http\Controllers\ClassController;
@@ -49,6 +50,11 @@ Route::prefix('auth')->group(function () {
         Route::post('/logout', [AuthController::class, 'logout']);
         Route::get('/me', [AuthController::class, 'me']);
     });
+});
+
+Route::prefix('profile')->middleware('auth:sanctum')->group(function () {
+    Route::patch('/update', [UserController::class, 'update']);
+    Route::delete('/destroy', [UserController::class, 'destroy']);
 });
 
 Route::middleware(['auth:sanctum', 'role:admin,teacher'])

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -1964,6 +1964,242 @@
                 }
             }
         },
+        "/api/profile/update": {
+            "post": {
+                "tags": [
+                    "Profile"
+                ],
+                "summary": "Update user profile",
+                "description": "Update authenticated user's profile including name, email, role, avatar, and bio.",
+                "operationId": "7c0bd54ef563ec1c42a6e9dd59871113",
+                "parameters": [
+                    {
+                        "name": "X-XSRF-TOKEN",
+                        "in": "header",
+                        "description": "CSRF token for session-based auth (Sanctum)",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "Referer",
+                        "in": "header",
+                        "description": "Referring URL Frontend for CSRF protection",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "example": "http://localhost:3000"
+                        }
+                    },
+                    {
+                        "name": "_method",
+                        "in": "query",
+                        "description": "Override HTTP method for PATCH requests",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "example": "PATCH"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "multipart/form-data": {
+                            "schema": {
+                                "required": [
+                                    "name",
+                                    "email",
+                                    "role"
+                                ],
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "example": "Fika"
+                                    },
+                                    "email": {
+                                        "type": "string",
+                                        "format": "email",
+                                        "example": "student2@example.com"
+                                    },
+                                    "role": {
+                                        "type": "string",
+                                        "enum": [
+                                            "student",
+                                            "teacher",
+                                            "admin"
+                                        ],
+                                        "example": "student"
+                                    },
+                                    "bio": {
+                                        "type": "string",
+                                        "example": "Lorem ipsum dolor sit amet"
+                                    },
+                                    "avatar": {
+                                        "description": "User avatar image file",
+                                        "type": "string",
+                                        "format": "binary"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "User updated successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "User updated successfully"
+                                        },
+                                        "data": {
+                                            "properties": {
+                                                "id": {
+                                                    "type": "string",
+                                                    "example": "d2fb93ec-6043-4384-814d-0e48f36aed50"
+                                                },
+                                                "name": {
+                                                    "type": "string",
+                                                    "example": "Fika"
+                                                },
+                                                "email": {
+                                                    "type": "string",
+                                                    "example": "student2@example.com"
+                                                },
+                                                "email_verified_at": {
+                                                    "type": "string",
+                                                    "example": null,
+                                                    "nullable": true
+                                                },
+                                                "role": {
+                                                    "type": "string",
+                                                    "example": "student"
+                                                },
+                                                "avatar": {
+                                                    "type": "string",
+                                                    "example": "/storage/avatar/687f8636256b0.png"
+                                                },
+                                                "bio": {
+                                                    "type": "string",
+                                                    "example": "Lorem ipsum dolor sit amet"
+                                                },
+                                                "created_at": {
+                                                    "type": "string",
+                                                    "format": "date-time",
+                                                    "example": "2025-07-17T07:08:54.000000Z"
+                                                },
+                                                "updated_at": {
+                                                    "type": "string",
+                                                    "format": "date-time",
+                                                    "example": "2025-07-22T12:38:14.000000Z"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthenticated"
+                    },
+                    "422": {
+                        "description": "Validation errors",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "errors": {
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Server error"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/profile/destroy": {
+            "delete": {
+                "tags": [
+                    "Profile"
+                ],
+                "summary": "Delete user profile",
+                "description": "Delete the authenticated user's account, including avatar file if present.",
+                "operationId": "25bd5807c8c305b9fe8f3dc9ccbd04b9",
+                "parameters": [
+                    {
+                        "name": "X-XSRF-TOKEN",
+                        "in": "header",
+                        "description": "CSRF token for session-based auth (Sanctum)",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "Referer",
+                        "in": "header",
+                        "description": "Referring URL Frontend for CSRF protection",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "example": "http://localhost:3000"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "User deleted successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "User deleted successfully"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthenticated"
+                    },
+                    "404": {
+                        "description": "User not found"
+                    },
+                    "500": {
+                        "description": "Server error"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
         "/api/vocab/categories": {
             "get": {
                 "tags": [
@@ -3033,6 +3269,10 @@
         {
             "name": "Test",
             "description": "Test"
+        },
+        {
+            "name": "Profile",
+            "description": "Profile"
         },
         {
             "name": "Vocabulary Categories",


### PR DESCRIPTION
### What’s added
- `UserController.php`:
  - `update()` method to update authenticated user's profile (`name`, `email`, `role`, `bio`, `avatar`)
  - `destroy()` method to delete user account and associated avatar file
- API routes under `/api/profile` (with `auth:sanctum` middleware):
  - `PATCH /profile/update`
  - `DELETE /profile/destroy`
- Swagger annotations for:
  - `POST /api/profile/update`
  - `DELETE /api/profile/destroy`

### What’s changed
- `ValidationHelper.php`: Added validation logic for profile update
- `AuthController.php`: Removed `avatar` and `bio` from request body during registration/login
- `routes/api.php`: Registered new profile routes
- `api-docs.json`: Updated OpenAPI documentation to reflect new endpoints

### Notes
- The `avatar` will be deleted from storage if updated or the account is deleted
- Allowed `role` values: `student`, `teacher`, `admin`
- Returns consistent JSON structure for success and errors
